### PR TITLE
Retrieve content details on videos to use the video's published date, then fallback to the RSS date

### DIFF
--- a/internal/models/podcast.go
+++ b/internal/models/podcast.go
@@ -39,7 +39,8 @@ type EpisodePlaybackHistory struct {
 }
 
 func NewPodcastEpisodeFromPlaylist(youtubeVideo *youtube.PlaylistItem) PodcastEpisode {
-	publishedAt, err := time.Parse("2006-01-02T15:04:05Z07:00", youtubeVideo.Snippet.PublishedAt)
+	// For PlaylistItems, use VideoPublishedAt for the actual publication date
+	publishedAt, err := time.Parse("2006-01-02T15:04:05Z07:00", youtubeVideo.ContentDetails.VideoPublishedAt)
 	if err != nil {
 		log.Error(err)
 	}

--- a/internal/services/playlist/playlistService.go
+++ b/internal/services/playlist/playlistService.go
@@ -38,7 +38,7 @@ func getYoutubePlaylistData(youtubePlaylistId string, service *ytApi.Service) {
 	pageToken := "first_call"
 
 	for continueRequestingPlaylistItems {
-		call := service.PlaylistItems.List([]string{"snippet", "status"}).
+		call := service.PlaylistItems.List([]string{"snippet", "status", "contentDetails"}).
 			PlaylistId(youtubePlaylistId).
 			MaxResults(50)
 		call.Header().Set("order", "publishedAt desc")


### PR DESCRIPTION
Hi, I noticed that when I would add a podcast, the episode dates were wrong (they would all show as the date of the latest video or something, i can't quite remember tbh). I originally [authored this change](https://github.com/noahkiss/go-podcast-sponsor-block/commit/d3cbef4) at the beginning of May to fix this issue. I haven't checked whether it's been fixed on your end yet or not, so I'm opening this so you can review and see whether it's necessary still.

Thanks!