### PR TITLE
fix ASC order playlist, add podcast refresh interval config

### DIFF
--- a/internal/app/controller.go
+++ b/internal/app/controller.go
@@ -4,10 +4,10 @@ import (
 	"ikoyhn/podcast-sponsorblock/internal/config"
 	"ikoyhn/podcast-sponsorblock/internal/database"
 	"ikoyhn/podcast-sponsorblock/internal/models"
+	"ikoyhn/podcast-sponsorblock/internal/services/channel"
 	"ikoyhn/podcast-sponsorblock/internal/services/common"
 	"ikoyhn/podcast-sponsorblock/internal/services/downloader"
 	"ikoyhn/podcast-sponsorblock/internal/services/playlist"
-	"ikoyhn/podcast-sponsorblock/internal/services/rss"
 	"ikoyhn/podcast-sponsorblock/internal/services/sponsorblock"
 	"net/http"
 	"os"
@@ -28,7 +28,7 @@ func registerRoutes(e *echo.Echo) {
 			return err
 		}
 		rssRequestParams := validateQueryParams(c)
-		data := rss.BuildChannelRssFeed(c.Param("channelId"), rssRequestParams, handler(c.Request()))
+		data := channel.BuildChannelRssFeed(c.Param("channelId"), rssRequestParams, handler(c.Request()))
 		c.Response().Header().Set("Content-Type", "application/rss+xml; charset=utf-8")
 		c.Response().Header().Set("Content-Length", strconv.Itoa(len(data)))
 		c.Response().Header().Del("Transfer-Encoding")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,11 +13,12 @@ import (
 
 type Config struct {
 	Setup struct {
-		GoogleApiKey string `mapstructure:"google-api-key" validate:"required"`
-		AudioDir     string
-		Cron         string `mapstructure:"cron"`
-		ConfigDir    string `mapstructure:"config-dir" validate:"required"`
-		DbFile       string
+		GoogleApiKey           string `mapstructure:"google-api-key" validate:"required"`
+		AudioDir               string
+		Cron                   string `mapstructure:"cron"`
+		ConfigDir              string `mapstructure:"config-dir" validate:"required"`
+		DbFile                 string
+		PodcastRefreshInterval string `mapstructure:"podcast-refresh-interval"`
 	} `mapstructure:"setup"`
 
 	Ntfy struct {
@@ -70,6 +71,7 @@ func Load() (*Config, error) {
 		v.ReadInConfig()
 	}
 
+	v.SetDefault("setup.podcast-refresh-interval", "1h")
 	v.SetDefault("ytdlp.episode-duration-minimum", "3m")
 	v.SetDefault("setup.config-dir", configDir)
 	v.SetDefault("setup.audio-dir", "audio")

--- a/internal/database/podcastRepository.go
+++ b/internal/database/podcastRepository.go
@@ -1,9 +1,10 @@
 package database
 
 import (
+	"ikoyhn/podcast-sponsorblock/internal/models"
+
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
-	"ikoyhn/podcast-sponsorblock/internal/models"
 )
 
 func PodcastExists(podcastId string) (bool, error) {
@@ -34,4 +35,8 @@ func GetPodcast(id string) *models.Podcast {
 
 func SavePodcast(podcast *models.Podcast) {
 	db.Create(&podcast)
+}
+
+func UpdatePodcast(podcast *models.Podcast) {
+	db.Save(podcast)
 }

--- a/internal/database/setupDatabase.go
+++ b/internal/database/setupDatabase.go
@@ -14,6 +14,7 @@ var db *gorm.DB
 
 func SetupDatabase() {
 	var err error
+	// Create the database file if it doesn't exist
 	if _, err := os.Stat(config.AppConfig.Setup.DbFile); os.IsNotExist(err) {
 		err := os.MkdirAll(config.AppConfig.Setup.ConfigDir, os.ModePerm)
 		if err != nil {

--- a/internal/services/rss/rssService.go
+++ b/internal/services/rss/rssService.go
@@ -4,12 +4,9 @@ import (
 	"encoding/xml"
 	"fmt"
 	"ikoyhn/podcast-sponsorblock/internal/config"
-	"ikoyhn/podcast-sponsorblock/internal/database"
 	"ikoyhn/podcast-sponsorblock/internal/enum"
 	"ikoyhn/podcast-sponsorblock/internal/models"
-	"ikoyhn/podcast-sponsorblock/internal/services/channel"
 	"ikoyhn/podcast-sponsorblock/internal/services/generator"
-	"ikoyhn/podcast-sponsorblock/internal/services/youtube"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -82,22 +79,6 @@ func GenerateRssFeed(podcast models.Podcast, host string, podcastType enum.Podca
 	}
 
 	return ytPodcast.Bytes()
-}
-
-func BuildChannelRssFeed(channelId string, params *models.RssRequestParams, host string) []byte {
-	log.Info("[RSS FEED] Building rss feed for channel...")
-
-	podcast := youtube.GetChannelData(channelId, false)
-
-	channel.GetChannelMetadataAndVideos(podcast.Id, params)
-	episodes, err := database.GetPodcastEpisodesByPodcastId(podcast.Id, enum.CHANNEL)
-	if err != nil {
-		log.Error(err)
-		return nil
-	}
-
-	podcastRss := BuildPodcast(podcast, episodes)
-	return GenerateRssFeed(podcastRss, host, enum.CHANNEL)
 }
 
 func BuildPodcast(podcast models.Podcast, allItems []models.PodcastEpisode) models.Podcast {

--- a/internal/services/youtube/youtubeService.go
+++ b/internal/services/youtube/youtubeService.go
@@ -27,10 +27,9 @@ func SetupYoutubeService() {
 	}
 	YtService = service
 }
-func GetChannelData(channelIdentifier string, isPlaylist bool) models.Podcast {
+func GetChannelData(dbPodcast *models.Podcast, channelIdentifier string, isPlaylist bool) *models.Podcast {
 	var channelCall *ytApi.ChannelsListCall
 	var channelId string
-	dbPodcast := database.GetPodcast(channelIdentifier)
 
 	if dbPodcast == nil {
 		if isPlaylist {
@@ -81,12 +80,11 @@ func GetChannelData(channelIdentifier string, isPlaylist bool) models.Podcast {
 			ArtistName:      channel.Snippet.Title,
 			Explicit:        "false",
 		}
-
-		dbPodcast.LastBuildDate = time.Now().Format(time.RFC1123)
-		database.SavePodcast(dbPodcast)
 	}
+	dbPodcast.LastBuildDate = time.Now().Format(time.RFC1123)
+	database.UpdatePodcast(dbPodcast)
 
-	return *dbPodcast
+	return dbPodcast
 }
 
 func GetVideoAndValidate(videoIdsNotSaved []string, missingVideos []models.PodcastEpisode) []models.PodcastEpisode {

--- a/properties.yml
+++ b/properties.yml
@@ -1,10 +1,12 @@
 ## Main settings for application
 # REQUIRED: "google-api-key"  - can either be set in here or in docker run command, view here to get an API key (https://developers.google.com/youtube/v3/getting-started)
 # OPTIONAL: "cron" - can be set manually, this is used to clean up old audio files that have not been accessed in one week (default)
+# OPTIONAL: "cron" - can be set manually, this is used to limit how often podcasts are refreshed from YouTube (default every 1h), Example values: (30s, 5m, 1hr)
 ###
 setup:
     google-api-key:
     cron:
+    podcast-refresh-interval:
 
 ### NTFY notifications, this requires a NTFY notifications server. Will allow you to receive notifications on episode download such as estimated download duration.
 ### NTFY docs can be found here (https://docs.ntfy.sh/)


### PR DESCRIPTION
Fix issue where new episodes would not be grabbed if Playlist had a custom order that was not DESC.
Added new property value to limit amount of refreshes per podcast to save on YT API tokens. Default is to only allow a podcast to grab new episodes every hour, this can be customized in the properties.yml